### PR TITLE
SEA-453 Responsible disclosure - Deploy SECURITY.md into public repository

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+At Prima, we take the security of our systems and data very seriously. We recognize the valuable role that security researchers and members of the public play in helping us identify and address potential security vulnerabilities. We encourage responsible disclosure of any vulnerabilities found in our systems, applications, or services to help us maintain the highest level of security for our customers.
+
+This policy applies to all Prima systems, applications, and services, including third-party systems that we use. We reserve the right to update or modify this policy at any time without prior notice.
+## How to report
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a potential vulnerability, you can send us an email to security-report@prima.it, following the guidelines in our Responsible Disclosure Policy. If you don’t feel comfortable sharing this information via plain text email, you can contact us at the same email address, and we will coordinate the establishment of an alternative secure channel.
+
+If the issue is confirmed, we will release a patch as soon as possible depending on complexity.
+
+For more details, please refer to our Responsible Disclosure Policy.


### PR DESCRIPTION
Adding SECURITY.md here to automatically have it in all org repos.

Ref: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/SEA-453